### PR TITLE
Melhorado script para instalar o Eclipse

### DIFF
--- a/app/desenvolvedor/eclipse.sh
+++ b/app/desenvolvedor/eclipse.sh
@@ -1,28 +1,19 @@
 #!/bin/bash
 
-usuario=$(./app/utils/UsuarioLogado.sh)
+ECLIPSE_URL="${ECLIPSE_URL:-http://eclipse.c3sl.ufpr.br/technology/epp/downloads/release/neon/2/eclipse-jee-neon-2-linux-gtk-x86_64.tar.gz}"
+ECLIPSE_PATH="${ECLIPSE_PATH:-/opt}"
 
-wget http://eclipse.c3sl.ufpr.br/technology/epp/downloads/release/neon/2/eclipse-jee-neon-2-linux-gtk-x86_64.tar.gz -O /home/$usuario/Downloads/eclipse-jee-neon-2-linux-gtk-x86_64.tar.gz
+wget "$ECLIPSE_URL" -O - | sudo tar xvzf - -C "$ECLIPSE_PATH"
 
-cd /home/$usuario/Downloads
+cat <<EOF | sudo tee /usr/share/applications/eclipse.desktop
+[Desktop Entry]
+Version=1.0
+Type=Application
+Terminal=false
+Name=Eclipse
+Exec=$ECLIPSE_PATH/eclipse/eclipse
+Icon=$ECLIPSE_PATH/eclipse/icon.xpm
+Categories=Application;Development;Java;IDE
+EOF
 
-sudo tar xvzf ./eclipse-jee-neon-2-linux-gtk-x86_64.tar.gz -C ./
-
-sudo mv ./eclipse /opt/
-
-sudo touch /usr/share/applications/eclipse.desktop
- 
-sudo chmod 666 /usr/share/applications/eclipse.desktop
- 
-sudo echo "[Desktop Entry]" > /usr/share/applications/eclipse.desktop
-sudo echo "Version=1.0" >> /usr/share/applications/eclipse.desktop
-sudo echo "Type=Application" >> /usr/share/applications/eclipse.desktop
-sudo echo "Terminal=false" >> /usr/share/applications/eclipse.desktop
-sudo echo "Name=Eclipse" >> /usr/share/applications/eclipse.desktop
-sudo echo "Exec=/opt/eclipse/eclipse" >> /usr/share/applications/eclipse.desktop
-sudo echo "Icon=/opt/eclipse/icon.xpm" >> /usr/share/applications/eclipse.desktop
-sudo echo "Categories=Application;Development;Java;IDE" >> /usr/share/applications/eclipse.desktop
- 
 sudo chmod 644 /usr/share/applications/eclipse.desktop
-
-sudo rm /home/$usuario/Downloads/eclipse-jee-neon-2-linux-gtk-x86_64.tar.gz


### PR DESCRIPTION
Sugestão de melhorias para os scripts:
- Usar variáveis de ambientes para poder definir algum parâmetro na execução.
  Exemplo: `ECLIPSE_PATH=/usr/local eclipse.sh` instala o Eclipse em `/usr/local/eclipse` em vez de `/opt/eclipse`.
- Fazer o download e já extrair os arquivos, sem ter que gravar primeiro no HD, para só depois extrair.
- Não dividir a criação de um arquivo de configuração em vários comandos.