### PR TITLE
Encerra script com erro caso haja problema na leitura da autenticação

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -26,5 +26,5 @@ if [[ "$usuario" != "" && "$senha" != "" && $validacaoLogin == "true" ]]; then
 	MenuPrincipal
 else
 	whiptail --title "Erro!" --msgbox "Houve um problema ao autenticar o usuário" 8 60
-	exit 0
+	exit 1
 fi


### PR DESCRIPTION
Ajustado o Exit Status para indicar que um erro ocorreu. Assim é possível usá-lo em conjunto com demais comandos do bash, exemplo: `./run.sh && echo 'Executado com sucesso' || echo 'Erro durante a execução'`.

Mais informações em:
- https://www.gnu.org/software/coreutils/manual/html_node/Exit-status.html#Exit-status
- https://www.gnu.org/software/bash/manual/bashref.html#Exit-Status